### PR TITLE
Revert "Remove dependabot (#54)"

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+# https://dependabot.com/docs/config-file/
+# https://dependabot.com/docs/config-file/validator/
+version: 1
+
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          update_type: "all"


### PR DESCRIPTION
This reverts commit 0742c57408d454fcc5ae8d76d5358a1fbd4fc389.

Renovate does not always update dependencies (or long delay?).