### PR TITLE
Update i18n to v1.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     erubi (1.10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)


### PR DESCRIPTION
Because v1.9.0 has been yanked.
https://github.com/ruby-i18n/i18n/issues/603#issuecomment-1023634942
